### PR TITLE
Fix no data alerts

### DIFF
--- a/alert-service/database/common_test.go
+++ b/alert-service/database/common_test.go
@@ -47,3 +47,31 @@ var alert2 model.Alert = model.Alert{
 	},
 	ID: utils.Str2oid("5dd4113f0085a6fac03c4fed"),
 }
+
+var alert3 model.Alert = model.Alert{
+	AlertCode:               model.AlertCodeNoData,
+	AlertSeverity:           model.AlertSeverityCritical,
+	AlertAffectedTechnology: nil,
+	AlertCategory:           model.AlertCategoryEngine,
+	AlertStatus:             model.AlertStatusNew,
+	Date:                    utils.P("2019-11-05T18:02:03Z"),
+	Description:             "test desc pippo",
+	OtherInfo: map[string]interface{}{
+		"hostname": "pippo-host",
+	},
+	ID: utils.Str2oid("5dd40bfb12f54dfda7b1c292"),
+}
+
+var alert4 model.Alert = model.Alert{
+	AlertCode:               model.AlertCodeNoData,
+	AlertSeverity:           model.AlertSeverityCritical,
+	AlertAffectedTechnology: nil,
+	AlertCategory:           model.AlertCategoryEngine,
+	AlertStatus:             model.AlertStatusNew,
+	Date:                    utils.P("2019-12-25T18:02:03Z"),
+	Description:             "test desc pluto",
+	OtherInfo: map[string]interface{}{
+		"hostname": "pluto-host",
+	},
+	ID: utils.Str2oid("5dd40bfb12f54dfda7b1c293"),
+}

--- a/alert-service/database/database.go
+++ b/alert-service/database/database.go
@@ -45,6 +45,8 @@ type MongoDatabaseInterface interface {
 	FindOldCurrentHosts(t time.Time) ([]string, utils.AdvancedErrorInterface)
 	// ExistNoDataAlertByHost return true if the host has associated a new NO_DATA alert
 	ExistNoDataAlertByHost(hostname string) (bool, utils.AdvancedErrorInterface)
+	// DeleteAllNoDataAlerts delete all alerts with code model.AlertCodeNoData
+	DeleteAllNoDataAlerts() utils.AdvancedErrorInterface
 }
 
 // MongoDatabase is a implementation
@@ -189,4 +191,17 @@ func (md *MongoDatabase) ExistNoDataAlertByHost(hostname string) (bool, utils.Ad
 
 	//Return true if the count > 0
 	return val > 0, nil
+}
+
+// DeleteAllNoDataAlerts delete all alerts with code model.AlertCodeNoData
+func (md *MongoDatabase) DeleteAllNoDataAlerts() utils.AdvancedErrorInterface {
+	_, err := md.Client.Database(md.Config.Mongodb.DBName).
+		Collection("alerts").
+		DeleteMany(context.TODO(), bson.M{"alertCode": model.AlertCodeNoData})
+
+	if err != nil {
+		return utils.NewAdvancedErrorPtr(err, "DB ERROR")
+	}
+
+	return nil
 }

--- a/alert-service/database/database.go
+++ b/alert-service/database/database.go
@@ -45,7 +45,9 @@ type MongoDatabaseInterface interface {
 	FindOldCurrentHosts(t time.Time) ([]model.HostDataBE, utils.AdvancedErrorInterface)
 	// ExistNoDataAlertByHost return true if the host has associated a new NO_DATA alert
 	ExistNoDataAlertByHost(hostname string) (bool, utils.AdvancedErrorInterface)
-	// DeleteAllNoDataAlerts delete all alerts with code model.AlertCodeNoData
+	// DeleteNoDataAlertByHost delete NO_DATA alert by hostname
+	DeleteNoDataAlertByHost(hostname string) utils.AdvancedErrorInterface
+	// DeleteAllNoDataAlerts delete all alerts with code NO_DATA
 	DeleteAllNoDataAlerts() utils.AdvancedErrorInterface
 }
 
@@ -199,7 +201,24 @@ func (md *MongoDatabase) ExistNoDataAlertByHost(hostname string) (bool, utils.Ad
 	return val > 0, nil
 }
 
-// DeleteAllNoDataAlerts delete all alerts with code model.AlertCodeNoData
+// DeleteNoDataAlertByHost delete NO_DATA alert by hostname
+func (md *MongoDatabase) DeleteNoDataAlertByHost(hostname string) utils.AdvancedErrorInterface {
+	_, err := md.Client.Database(md.Config.Mongodb.DBName).
+		Collection("alerts").
+		DeleteOne(context.TODO(),
+			bson.M{
+				"alertCode":          model.AlertCodeNoData,
+				"otherInfo.hostname": hostname,
+			})
+
+	if err != nil {
+		return utils.NewAdvancedErrorPtr(err, "DB ERROR")
+	}
+
+	return nil
+}
+
+// DeleteAllNoDataAlerts delete all alerts with code NO_DATA
 func (md *MongoDatabase) DeleteAllNoDataAlerts() utils.AdvancedErrorInterface {
 	_, err := md.Client.Database(md.Config.Mongodb.DBName).
 		Collection("alerts").

--- a/alert-service/database/database_test.go
+++ b/alert-service/database/database_test.go
@@ -199,3 +199,37 @@ func (m *MongodbSuite) TestExistNoDataAlert_SuccessExist() {
 
 	assert.True(m.T(), exist)
 }
+
+func (m *MongodbSuite) TestDeleteAllNoDataAlerts_Success() {
+	_, err := m.db.InsertAlert(alert1)
+	require.NoError(m.T(), err)
+
+	_, err = m.db.InsertAlert(alert3)
+	require.NoError(m.T(), err)
+	_, err = m.db.InsertAlert(alert4)
+	require.NoError(m.T(), err)
+
+	err = m.db.DeleteAllNoDataAlerts()
+	require.NoError(m.T(), err)
+
+	// Check that there are no more AlertCodeNoData alerts
+	val, erro := m.db.Client.Database(m.dbname).Collection("alerts").
+		Find(context.TODO(), bson.M{"alertCode": model.AlertCodeNoData})
+	require.NoError(m.T(), erro)
+
+	res := make([]model.Alert, 0)
+	erro = val.All(context.TODO(), &res)
+	require.NoError(m.T(), erro)
+	require.Equal(m.T(), 0, len(res))
+
+	// Check that there's still alert1
+	val, erro = m.db.Client.Database(m.dbname).Collection("alerts").
+		Find(context.TODO(), bson.M{})
+	require.NoError(m.T(), erro)
+
+	res = make([]model.Alert, 0)
+	erro = val.All(context.TODO(), &res)
+	require.NoError(m.T(), erro)
+	require.Equal(m.T(), 1, len(res))
+	require.Equal(m.T(), alert1, (res)[0])
+}

--- a/alert-service/database/database_test.go
+++ b/alert-service/database/database_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sort"
 	"testing"
 
 	"github.com/ercole-io/ercole/config"
@@ -164,8 +165,10 @@ func (m *MongodbSuite) TestFindOldCurrentHosts() {
 		require.NoError(t, err)
 
 		assert.Len(t, hosts, 1)
-		expectedHosts := append(make([]string, 0), "itl-csllab-112.sorint.localpippo")
-		assert.ElementsMatch(t, expectedHosts, hosts)
+
+		assert.Equal(m.T(), "itl-csllab-112.sorint.localpippo", hosts[0].Hostname)
+		assert.False(m.T(), hosts[0].Archived)
+		assert.Equal(m.T(), utils.P("2019-11-19T16:38:58Z"), hosts[0].CreatedAt)
 	})
 
 	m.T().Run("Should find two", func(t *testing.T) {
@@ -173,8 +176,18 @@ func (m *MongodbSuite) TestFindOldCurrentHosts() {
 		require.NoError(t, err)
 
 		assert.Len(t, hosts, 2)
-		expectedHosts := append(make([]string, 0), "itl-csllab-112.sorint.localpippo", "itl-csllab-223.sorint.localpippo")
-		assert.ElementsMatch(t, expectedHosts, hosts)
+
+		sort.Slice(hosts, func(i, j int) bool {
+			return hosts[i].ID.String() < hosts[j].ID.String()
+		})
+
+		assert.Equal(m.T(), "itl-csllab-112.sorint.localpippo", hosts[0].Hostname)
+		assert.False(m.T(), hosts[0].Archived)
+		assert.Equal(m.T(), utils.P("2019-11-19T16:38:58Z"), hosts[0].CreatedAt)
+
+		assert.Equal(m.T(), "itl-csllab-223.sorint.localpippo", hosts[1].Hostname)
+		assert.False(m.T(), hosts[1].Archived)
+		assert.Equal(m.T(), utils.P("2020-01-13T15:38:58Z"), hosts[1].CreatedAt)
 	})
 }
 

--- a/alert-service/service/alert_thrower.go
+++ b/alert-service/service/alert_thrower.go
@@ -145,7 +145,7 @@ func (as *AlertService) ThrowNoDataAlert(hostname string, freshnessThreshold int
 		AlertSeverity:           model.AlertSeverityCritical,
 		AlertStatus:             model.AlertStatusNew,
 		Date:                    as.TimeNow(),
-		Description:             fmt.Sprintf("No data received from the host %s in the last %d days", hostname, freshnessThreshold),
+		Description:             fmt.Sprintf("No data received from the host %s in the last %d day(s)", hostname, freshnessThreshold),
 		OtherInfo: map[string]interface{}{
 			"hostname": hostname,
 		},

--- a/alert-service/service/alert_thrower_test.go
+++ b/alert-service/service/alert_thrower_test.go
@@ -235,7 +235,7 @@ func TestThrowNoDataAlert_Success(t *testing.T) {
 		assert.Equal(t, model.AlertCodeNoData, alert.AlertCode)
 		assert.Equal(t, model.AlertSeverityCritical, alert.AlertSeverity)
 		assert.Equal(t, model.AlertStatusNew, alert.AlertStatus)
-		assert.Equal(t, "No data received from the host myhost in the last 90 days", alert.Description)
+		assert.Equal(t, "No data received from the host myhost in the last 90 day(s)", alert.Description)
 		assert.Equal(t, map[string]interface{}{
 			"hostname": "myhost",
 		}, alert.OtherInfo)

--- a/alert-service/service/freshness_check_job.go
+++ b/alert-service/service/freshness_check_job.go
@@ -41,6 +41,13 @@ type FreshnessCheckJob struct {
 
 // Run throws NO_DATA alert for each hosts that haven't sent a hostdata withing the FreshnessCheck.DaysThreshold
 func (job *FreshnessCheckJob) Run() {
+	if job.Config.AlertService.FreshnessCheckJob.DaysThreshold <= 0 {
+		job.Log.Errorf("AlertService.FreshnessCheckJob.DaysThreshold must be higher than 0, but it's set to %v. Job failed.",
+			job.Config.AlertService.FreshnessCheckJob.DaysThreshold)
+
+		return
+	}
+
 	//Find the current hosts older than FreshnessCheck.DaysThreshold days
 	hosts, err := job.Database.FindOldCurrentHosts(job.TimeNow().AddDate(0, 0, -job.Config.AlertService.FreshnessCheckJob.DaysThreshold))
 	if err != nil {

--- a/alert-service/service/service.go
+++ b/alert-service/service/service.go
@@ -88,7 +88,13 @@ func (as *AlertService) Init(wg *sync.WaitGroup) {
 
 	jobrunner.Start()
 
-	freshnessJob := &FreshnessCheckJob{alertService: as, TimeNow: as.TimeNow, Database: as.Database, Log: as.Log}
+	freshnessJob := &FreshnessCheckJob{
+		TimeNow:      as.TimeNow,
+		Database:     as.Database,
+		Config:       as.Config,
+		alertService: as,
+		Log:          as.Log,
+	}
 
 	if err := jobrunner.Schedule(as.Config.AlertService.FreshnessCheckJob.Crontab, freshnessJob); err != nil {
 		as.Log.Errorf("Something went wrong scheduling FreshnessCheckJob: %v", err)

--- a/alert-service/service/service.go
+++ b/alert-service/service/service.go
@@ -172,6 +172,8 @@ func (as *AlertService) ProcessHostDataInsertion(params hub.Fields) {
 			as.ThrowUnlistedRunningDatabasesAlert(dbname, newData.Hostname)
 		}
 	}
+
+	//TODO If there is a NO_DATA alert for this HostData, remove it
 }
 
 // ProcessAlertInsertion processes the alert insertion event

--- a/alert-service/service/service.go
+++ b/alert-service/service/service.go
@@ -173,7 +173,9 @@ func (as *AlertService) ProcessHostDataInsertion(params hub.Fields) {
 		}
 	}
 
-	//TODO If there is a NO_DATA alert for this HostData, remove it
+	if err := as.Database.DeleteNoDataAlertByHost(newData.Hostname); err != nil {
+		as.Log.Error(err)
+	}
 }
 
 // ProcessAlertInsertion processes the alert insertion event

--- a/alert-service/service/service_test.go
+++ b/alert-service/service/service_test.go
@@ -58,6 +58,7 @@ func TestProcessMsg_HostDataInsertion(t *testing.T) {
 			assert.Nil(t, alert.AlertAffectedTechnology)
 		}),
 	)
+	db.EXPECT().DeleteNoDataAlertByHost("superhost1")
 
 	msg := hub.Message{
 		Name: "hostdata.insertion",

--- a/alert-service/service/service_test.go
+++ b/alert-service/service/service_test.go
@@ -134,6 +134,7 @@ func TestProcessHostDataInsertion_SuccessNewHost(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	db := NewMockMongoDatabaseInterface(mockCtrl)
+
 	as := AlertService{
 		Database: db,
 		TimeNow:  utils.Btc(utils.P("2019-11-05T14:02:03Z")),
@@ -141,10 +142,10 @@ func TestProcessHostDataInsertion_SuccessNewHost(t *testing.T) {
 		Queue:    hub.New(),
 	}
 
-	db.EXPECT().FindHostData(utils.Str2oid("5dc3f534db7e81a98b726a52")).Return(hostData1, nil).Times(1)
-	db.EXPECT().FindHostData(gomock.Any()).Times(0)
-	db.EXPECT().FindMostRecentHostDataOlderThan("superhost1", utils.P("2019-11-05T14:02:03Z")).Return(emptyHostData, nil).Times(1)
-	db.EXPECT().FindMostRecentHostDataOlderThan(gomock.Any(), gomock.Any()).Return(model.HostDataBE{}, nil).Times(0)
+	db.EXPECT().FindHostData(utils.Str2oid("5dc3f534db7e81a98b726a52")).
+		Return(hostData1, nil).Times(1)
+	db.EXPECT().FindMostRecentHostDataOlderThan("superhost1", utils.P("2019-11-05T14:02:03Z")).
+		Return(emptyHostData, nil).Times(1)
 
 	db.EXPECT().InsertAlert(gomock.Any()).Return(nil, nil).Do(func(alert model.Alert) {
 		assert.Equal(t, utils.P("2019-11-05T14:02:03Z"), alert.Date)
@@ -158,6 +159,8 @@ func TestProcessHostDataInsertion_SuccessNewHost(t *testing.T) {
 			assert.Nil(t, alert.AlertAffectedTechnology)
 		}),
 	)
+
+	db.EXPECT().DeleteNoDataAlertByHost(hostData1.Hostname)
 
 	as.ProcessHostDataInsertion(hub.Fields{
 		"id": utils.Str2oid("5dc3f534db7e81a98b726a52"),

--- a/model/queue_events.go
+++ b/model/queue_events.go
@@ -16,8 +16,8 @@
 package model
 
 const (
-	// TopicHostDataInsertion is the topic used when a hostdata is inserted in the db
+	// TopicHostDataInsertion is the topic used when an hostdata is inserted in the db
 	TopicHostDataInsertion string = "hostdata.insertion"
-	// TopicAlertInsertion is the topic used when a aler is inserted in the db
+	// TopicAlertInsertion is the topic used when an alert is inserted in the db
 	TopicAlertInsertion string = "alert.insertion"
 )


### PR DESCRIPTION
Fix #334 

Since alerts contain "in the last xxx days", I need to remove all alerts and reinsert them with right value when FreshnessCheckJob is run.

Maybe we should force to run it at least once a day ( AlertService.FreshnessCheckJob.Crontab param ).

TODO:

- [x] Choose what FindOldCurrentHosts must return
- [x] 	//TODO remove mongo-driver dependency from here...
- [x] 	//TODO If there is a NO_DATA alert for this HostData, remove it
- [x] Fix tests