### PR TITLE
Fix Option to ignore usage of a license

### DIFF
--- a/api-service/database/oracle_database_licenses.go
+++ b/api-service/database/oracle_database_licenses.go
@@ -75,11 +75,11 @@ func (md *MongoDatabase) UpdateLicenseIgnoredField(hostname string, dbname strin
 			bson.M{
 				"hostname": hostname,
 				"archived": false,
-				"features.oracle.database.databases.instanceName":           dbname,
+				"features.oracle.database.databases.name":                   dbname,
 				"features.oracle.database.databases.licenses.licenseTypeID": licenseTypeID,
 			},
 			bson.M{"$set": bson.M{"features.oracle.database.databases.$[elemDB].licenses.$[elemLic].ignored": ignored}},
-			options.Update().SetArrayFilters(options.ArrayFilters{Filters: []interface{}{bson.M{"elemDB.instanceName": dbname}, bson.M{"elemLic.licenseTypeID": licenseTypeID}}}),
+			options.Update().SetArrayFilters(options.ArrayFilters{Filters: []interface{}{bson.M{"elemDB.name": dbname}, bson.M{"elemLic.licenseTypeID": licenseTypeID}}}),
 		)
 	if err != nil {
 		return utils.NewError(err, "DB ERROR")

--- a/api-service/database/oracle_database_licenses_test.go
+++ b/api-service/database/oracle_database_licenses_test.go
@@ -129,7 +129,7 @@ func (m *MongodbSuite) TestLicenseHostIgnoredField_Success() {
 
 	m.T().Run("update_ignored_success", func(t *testing.T) {
 
-		hostname, dbname, licenseTypeID := "test-db", "ERCOLE1", "A90611"
+		hostname, dbname, licenseTypeID := "test-db", "ERCOLE", "A90611"
 		ignored := true
 
 		err := m.db.UpdateLicenseIgnoredField(hostname, dbname, licenseTypeID, ignored)
@@ -140,7 +140,7 @@ func (m *MongodbSuite) TestLicenseHostIgnoredField_Success() {
 		var resultIgnored bool
 		for i := range hostData.Features.Oracle.Database.Databases {
 			db := &hostData.Features.Oracle.Database.Databases[i]
-			if db.InstanceName == dbname {
+			if db.Name == dbname {
 				for j := range db.Licenses {
 					lic := &db.Licenses[j]
 					if lic.LicenseTypeID == licenseTypeID {

--- a/api-service/service/databases.go
+++ b/api-service/service/databases.go
@@ -206,16 +206,6 @@ func (as *APIService) GetDatabasesUsedLicenses(filter dto.GlobalFilter) ([]dto.D
 			continue
 		}
 
-		clusterCores, err := hostdata.GetClusterCores(hostdatasPerHostname)
-		if errors.Is(err, utils.ErrHostNotInCluster) {
-			continue
-		} else if err != nil {
-			return nil, err
-		}
-		consumedLicenses := float64(clusterCores) * hostdata.CoreFactor()
-
-		usedLicenses[i].ClusterLicenses = consumedLicenses
-
 		if hostdata.Features.Oracle != nil && hostdata.Features.Oracle.Database != nil && hostdata.Features.Oracle.Database.Databases != nil {
 			for x := range hostdata.Features.Oracle.Database.Databases {
 				if hostdata.Features.Oracle.Database.Databases[x].Name == usedLicenses[i].DbName {
@@ -228,6 +218,16 @@ func (as *APIService) GetDatabasesUsedLicenses(filter dto.GlobalFilter) ([]dto.D
 				}
 			}
 		}
+		clusterCores, err := hostdata.GetClusterCores(hostdatasPerHostname)
+		if errors.Is(err, utils.ErrHostNotInCluster) {
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+		consumedLicenses := float64(clusterCores) * hostdata.CoreFactor()
+
+		usedLicenses[i].ClusterLicenses = consumedLicenses
+
 	}
 
 	return usedLicenses, nil


### PR DESCRIPTION
Fix #709 Fix Option to ignore usage of a license in filter update condition and in Used License API