### PR TITLE
Change consumed covered compliance calculations when host belongs to cluster

### DIFF
--- a/api-service/service/databases_test.go
+++ b/api-service/service/databases_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sorint.lab S.p.A.
+// Copyright (c) 2022 Sorint.lab S.p.A.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -741,8 +741,8 @@ func TestGetDatabaseLicensesComplianceAsXLSX_Success(t *testing.T) {
 	assert.Equal(t, "Oracle Advanced Compression", actual.GetCellValue("Licenses Compliance", "B2"))
 	assert.Equal(t, "Named User Plus Perpetual", actual.GetCellValue("Licenses Compliance", "C2"))
 	assert.Equal(t, "150", actual.GetCellValue("Licenses Compliance", "D2"))
-	assert.Equal(t, "3750", actual.GetCellValue("Licenses Compliance", "E2"))
-	assert.Equal(t, "25", actual.GetCellValue("Licenses Compliance", "F2"))
+	assert.Equal(t, "150", actual.GetCellValue("Licenses Compliance", "E2"))
+	assert.Equal(t, "1", actual.GetCellValue("Licenses Compliance", "F2"))
 	assert.Equal(t, "0", actual.GetCellValue("Licenses Compliance", "G2"))
 	assert.Equal(t, "", actual.GetCellValue("Licenses Compliance", "H2"))
 }
@@ -908,9 +908,9 @@ func TestGetDatabaseLicensesCompliance_Success(t *testing.T) {
 			ItemDescription: "Oracle Partitioning",
 			Metric:          "Named User Plus Perpetual",
 			Consumed:        500,
-			Covered:         6250,
+			Covered:         500,
 			Purchased:       450,
-			Compliance:      12.5,
+			Compliance:      1,
 			Unlimited:       false,
 			Available:       200,
 		},

--- a/api-service/service/oracle_database_license_types_test.go
+++ b/api-service/service/oracle_database_license_types_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Sorint.lab S.p.A.
+// Copyright (c) 2022 Sorint.lab S.p.A.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -226,9 +226,9 @@ func TestGetLicensesCompliance(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []dto.LicenseCompliance{
-		{LicenseTypeID: "PID001", ItemDescription: "itemDesc1", Metric: "Processor Perpetual", Consumed: 10, Covered: 0, Purchased: 10, Compliance: 0, Available: 3, Unlimited: false},
-		{LicenseTypeID: "PID002", ItemDescription: "itemDesc2", Metric: "Named User Plus Perpetual", Consumed: 250, Covered: 0, Purchased: 500, Compliance: 0, Available: 250, Unlimited: false},
-		{LicenseTypeID: "PID003", ItemDescription: "itemDesc3", Metric: "Computer Perpetual", Consumed: 11, Covered: 0, Purchased: 0, Compliance: 1, Available: 0, Unlimited: true},
+		{LicenseTypeID: "PID001", ItemDescription: "itemDesc1", Metric: "Processor Perpetual", Consumed: 10, Covered: 7, Purchased: 10, Compliance: 0.7, Available: 3, Unlimited: false},
+		{LicenseTypeID: "PID002", ItemDescription: "itemDesc2", Metric: "Named User Plus Perpetual", Consumed: 250, Covered: 6250, Purchased: 500, Compliance: 25, Available: 250, Unlimited: false},
+		{LicenseTypeID: "PID003", ItemDescription: "itemDesc3", Metric: "Computer Perpetual", Consumed: 11, Covered: 11, Purchased: 0, Compliance: 1, Available: 0, Unlimited: true},
 		{LicenseTypeID: "PID004", ItemDescription: "itemDesc4", Metric: "Computer Perpetual", Consumed: 0.0, Covered: 0.0, Purchased: 40, Compliance: 1, Available: 40, Unlimited: false},
 		{LicenseTypeID: "PID005", ItemDescription: "itemDesc5", Metric: "Computer Perpetual", Consumed: 12, Covered: 0.0, Purchased: 0, Compliance: 0, Available: 0, Unlimited: false},
 	}


### PR DESCRIPTION
Fix #734 Change consumed covered compliance calculations when host belongs to cluster