### PR TITLE
Ignoring RAC licenses

### DIFF
--- a/data-service/service/oracle_databases.go
+++ b/data-service/service/oracle_databases.go
@@ -48,6 +48,8 @@ func (hds *HostDataService) oracleDatabasesChecks(previousHostdata, hostdata *mo
 
 	hds.ignorePreviousLicences(previousHostdata, hostdata)
 
+	hds.ignoreRacLicenses(hostdata)
+
 	var unlistedDatabasesAlerts []model.Alert
 
 	for _, dbname := range hostdata.Features.Oracle.Database.UnlistedRunningDatabases {
@@ -429,6 +431,17 @@ func (hds *HostDataService) ignorePreviousLicences(previous, new *model.HostData
 						db.Licenses[i].IgnoredComment = v.comment
 					}
 				}
+			}
+		}
+	}
+}
+
+func (hds *HostDataService) ignoreRacLicenses(host *model.HostDataBE) {
+	for _, db := range host.Features.Oracle.Database.Databases {
+		for i := range db.Licenses {
+			if db.Edition() == model.OracleDatabaseEditionStandard && db.Licenses[i].IsRAC() {
+				db.Licenses[i].Ignored = true
+				db.Licenses[i].IgnoredComment = "RAC license ignored by Ercole"
 			}
 		}
 	}

--- a/fixture/test_dataservice_hostdata_v1_24.json
+++ b/fixture/test_dataservice_hostdata_v1_24.json
@@ -1,0 +1,184 @@
+{
+    "hostname": "itl-csllab-112.sorint.localpippo",
+    "environment": "TST",
+    "location": "Germany",
+    "info": {
+        "hostname": "itl-csllab-112.sorint.localpippo",
+        "cpuModel": "Intel(R) Xeon(R) CPU           E5630  @ 2.53GHz",
+        "cpuCores": 1,
+        "cpuThreads": 2,
+        "kernel": "3.10.0-514.el7.x86_64",
+        "os": "Red Hat Enterprise Linux",
+        "memoryTotal": 3,
+        "swapTotal": 1,
+        "cpuFrequency": "2.53GHz",
+        "cpuSockets": 2,
+        "coresPerSocket": 1,
+        "threadsPerCore": 2,
+        "kernelVersion": "3.10.0-514.el7.x86_64",
+        "osVersion": "7.6",
+        "hardwareAbstraction": "VIRT",
+        "hardwareAbstractionTechnology": "VMWARE"
+    },
+    "agentVersion": "latest",
+    "tags": [],
+    "schemaVersion": 1,
+    "clusterMembershipStatus": {
+        "oracleClusterware": false,
+        "veritasClusterServer": false,
+        "sunCluster": false,
+        "hacmp": false
+    },
+    "filesystems": [
+        {
+            "filesystem": "/dev/mapper/cl_itl--csllab--112-root",
+            "size": 13958643712,
+            "mountedOn": "/",
+            "availableSpace": 5798205849,
+            "usedSpace": 7194070220,
+            "type": "ext4"
+        }
+    ],
+    "features": {
+        "oracle": {
+            "database": {
+                "unlistedRunningDatabases": [],
+                "databases": [
+                    {
+                        "instanceNumber": 1,
+                        "name": "ERCOLE",
+                        "instanceName": "ERCOLE1",
+                        "uniqueName": "ERCOLE",
+                        "status": "OPEN",
+                        "dbID": 1,
+                        "role": "PRIMARY",
+                        "version": "12.2.0.1.0 Standard Edition",
+                        "platform": "Linux x86 64-bit",
+                        "archivelog": false,
+                        "charset": "AL32UTF8",
+                        "nCharset": "AL16UTF16",
+                        "blockSize": 8192,
+                        "cpuCount": 2,
+                        "sgaTarget": 0.0,
+                        "pgaTarget": 0.0,
+                        "memoryTarget": 1.484,
+                        "sgaMaxSize": 1.484,
+                        "segmentsSize": 3.0,
+                        "allocable": 129.0,
+                        "elapsed": 12059.18,
+                        "dbTime": 184.81,
+                        "dailyCPUUsage": 0.5,
+                        "work": 1.0,
+                        "asm": false,
+                        "dataguard": false,
+                        "patches": [],
+                        "tablespaces": [
+                            {
+                                "name": "SYSTEM",
+                                "maxSize": 32767.9844,
+                                "total": 850.0,
+                                "used": 842.875,
+                                "usedPerc": 2.57,
+                                "status": "ONLINE"
+                            },
+                            {
+                                "name": "USERS",
+                                "maxSize": 32767.9844,
+                                "total": 1024.0,
+                                "used": 576.0,
+                                "usedPerc": 1.76,
+                                "status": "ONLINE"
+                            },
+                            {
+                                "name": "UNDOTBS1",
+                                "maxSize": 32767.9844,
+                                "total": 895.0,
+                                "used": 41.25,
+                                "usedPerc": 0.13,
+                                "status": "ONLINE"
+                            },
+                            {
+                                "name": "SYSAUX",
+                                "maxSize": 32767.9844,
+                                "total": 1870.0,
+                                "used": 1749.625,
+                                "usedPerc": 5.34,
+                                "status": "ONLINE"
+                            }
+                        ],
+                        "schemas": [
+                            {
+                                "user": "ERCOLE",
+                                "total": 384,
+                                "tables": 384,
+                                "indexes": 0,
+                                "lob": 0,
+                                "accountStatus": "status"
+                            },
+                            {
+                                "user": "SYSRAC",
+                                "total": 0,
+                                "tables": 0,
+                                "indexes": 0,
+                                "lob": 0,
+                                "accountStatus": "status"
+                            }
+                        ],
+                        "licenses": [
+                            {
+                                "licenseTypeID": "A90619",
+                                "count": 1,
+                                "name": "Real Application Clusters"
+                            },
+                            {
+                                "licenseTypeID":"A90649",
+                                "name": "Diagnostics Pack",
+                                "count": 0.5
+                            }
+                        ],
+                        "addms": [],
+                        "segmentAdvisors": [],
+                        "backups": [],
+                        "datafileSize": 6.0,
+                        "psus": [],
+                        "featureUsageStats": [
+                            {
+                                "product": "Diagnostics Pack",
+                                "feature": "ADDM",
+                                "detectedUsages": 91,
+                                "currentlyUsed": false,
+                                "firstUsageDate": "2019-06-24T17:34:20Z",
+                                "lastUsageDate": "2019-11-09T04:48:23Z",
+                                "extraFeatureInfo": ""
+                            },
+                            {
+                                "product": "Diagnostics Pack",
+                                "feature": "AWR Report",
+                                "detectedUsages": 90,
+                                "currentlyUsed": false,
+                                "firstUsageDate": "2019-06-27T15:15:44Z",
+                                "lastUsageDate": "2019-11-09T04:48:23Z",
+                                "extraFeatureInfo": ""
+                            },
+                            {
+                                "product": "Diagnostics Pack",
+                                "feature": "Automatic Workload Repository",
+                                "detectedUsages": 7,
+                                "currentlyUsed": false,
+                                "firstUsageDate": "2019-06-27T17:01:09Z",
+                                "lastUsageDate": "2019-07-02T05:35:05Z",
+                                "extraFeatureInfo": ""
+                            }
+                        ],
+                        "isCDB": false,
+                        "isRAC": true,
+                        "pdbs": [],
+                        "services": []
+                    }
+                ]
+            }
+        }
+    },
+    "clusters": null,
+    "grantDba": null
+}

--- a/model/oracle_database_license.go
+++ b/model/oracle_database_license.go
@@ -15,6 +15,8 @@
 
 package model
 
+import "github.com/ercole-io/ercole/v2/utils"
+
 // OracleDatabaseLicense holds information about an Oracle database license
 type OracleDatabaseLicense struct {
 	LicenseTypeID  string  `json:"licenseTypeID" bson:"licenseTypeID"`
@@ -76,4 +78,9 @@ func DiffLicenses(oldLicenses, newLicenses []OracleDatabaseLicense) map[string]i
 	}
 
 	return result
+}
+
+func (l *OracleDatabaseLicense) IsRAC() bool {
+	rac_licenses := []string{"A90619", "L10005", "L76094", "L76084"}
+	return utils.Contains(rac_licenses, l.LicenseTypeID)
 }


### PR DESCRIPTION
Ignored licenses when Oracle database is `standard edition` and the license is a RAC type.

Resolve #1453 