### PR TITLE
Removed min length to oracle db backup retention

### DIFF
--- a/schema/oracle.json
+++ b/schema/oracle.json
@@ -471,7 +471,6 @@
                                                 },
                                                 "retention": {
                                                     "type": "string",
-                                                    "minLength": 1,
                                                     "maxLength": 16
                                                 }
                                             }


### PR DESCRIPTION
Resolve #1597 