### PR TITLE
Added oracle db migrate status

### DIFF
--- a/api-service/controller/controller.go
+++ b/api-service/controller/controller.go
@@ -110,6 +110,9 @@ type APIControllerInterface interface {
 
 	// UpdateLicenseIgnoredField update license ignored field (true/false)
 	UpdateLicenseIgnoredField(w http.ResponseWriter, r *http.Request)
+
+	CanMigrateLicense(w http.ResponseWriter, r *http.Request)
+
 	// UpdateSqlServerLicenseIgnoredField update license ignored field (true/false)
 	UpdateSqlServerLicenseIgnoredField(w http.ResponseWriter, r *http.Request)
 	// UpdateMySqlLicenseIgnoredField update license ignored field (true/false)

--- a/api-service/controller/oracle_database_licenses.go
+++ b/api-service/controller/oracle_database_licenses.go
@@ -65,3 +65,22 @@ func (ctrl *APIController) UpdateLicenseIgnoredField(w http.ResponseWriter, r *h
 	//Write the data
 	utils.WriteJSONResponse(w, http.StatusOK, nil)
 }
+
+func (ctrl *APIController) CanMigrateLicense(w http.ResponseWriter, r *http.Request) {
+	hostname := mux.Vars(r)["hostname"]
+	dbname := mux.Vars(r)["dbname"]
+
+	res, err := ctrl.Service.CanMigrateLicense(hostname, dbname)
+	if err != nil {
+		utils.WriteAndLogError(ctrl.Log, w, http.StatusUnprocessableEntity, err)
+		return
+	}
+
+	resJSON := struct {
+		Canbemigrate bool
+	}{
+		Canbemigrate: res,
+	}
+
+	utils.WriteJSONResponse(w, http.StatusOK, resJSON)
+}

--- a/api-service/controller/routing.go
+++ b/api-service/controller/routing.go
@@ -151,6 +151,9 @@ func (ctrl *APIController) setupProtectedRoutes(router *mux.Router) {
 	router.HandleFunc("/contracts/oracle/database/{id}/hosts", ctrl.AddHostToOracleDatabaseContract).Methods("POST")
 	router.HandleFunc("/contracts/oracle/database/{id}/hosts/{hostname}", ctrl.DeleteHostFromOracleDatabaseContract).Methods("DELETE")
 
+	// ORACLE LICENSE
+	router.HandleFunc("/hosts/{hostname}/technologies/oracle/databases/{dbname}/can-migrate", ctrl.CanMigrateLicense).Methods("GET")
+
 	// SQL SERVER CONTRACTS
 	router.HandleFunc("/contracts/microsoft/database", ctrl.AddSqlServerDatabaseContract).Methods("POST")
 	router.HandleFunc("/contracts/microsoft/database", ctrl.UpdateSqlServerDatabaseContract).Methods("PUT")

--- a/api-service/database/database.go
+++ b/api-service/database/database.go
@@ -128,6 +128,8 @@ type MongoDatabaseInterface interface {
 	// UpdateLicenseIgnoredField update license ignored field (true/false)
 	UpdateLicenseIgnoredField(hostname string, dbname string, licenseTypeID string, ignored bool, ignoredComment string) error
 
+	CanMigrateLicense(hostname string, dbname string) (bool, error)
+
 	// InsertOracleDatabaseLicenseType insert an Oracle/Database license type into the database
 	InsertOracleDatabaseLicenseType(licenseType model.OracleDatabaseLicenseType) error
 	// UpdateOracleDatabaseLicenseType update an Oracle/Database license type in the database

--- a/api-service/database/oracle_database_licenses.go
+++ b/api-service/database/oracle_database_licenses.go
@@ -100,3 +100,30 @@ func (md *MongoDatabase) UpdateLicenseIgnoredField(hostname string, dbname strin
 
 	return nil
 }
+
+// If an oracle database has just an enterprise license can be migrated to a standard license.
+// CanMigrateLicense return if the database can be migrated or not.
+func (md *MongoDatabase) CanMigrateLicense(hostname string, dbname string) (bool, error) {
+	stage := bson.A{
+		bson.M{"$match": bson.M{"archived": false}},
+		bson.M{"$match": bson.M{"hostname": hostname}},
+		bson.M{"$unwind": "$features.oracle.database.databases"},
+		bson.M{"$match": bson.M{"features.oracle.database.databases.name": dbname}},
+		bson.M{"$unwind": "$features.oracle.database.databases.licenses"},
+		bson.M{"$match": bson.M{"features.oracle.database.databases.licenses.name": "Oracle ENT"}},
+		bson.M{"$project": bson.M{"license": "$features.oracle.database.databases.licenses"}},
+	}
+
+	cur, err := md.Client.Database(md.Config.Mongodb.DBName).Collection("hosts").
+		Aggregate(context.TODO(), stage)
+	if err != nil {
+		return false, err
+	}
+
+	var res []bson.D
+	if err = cur.All(context.TODO(), &res); err != nil {
+		return false, err
+	}
+
+	return len(res) > 0, nil
+}

--- a/api-service/service/oracle_database_licenses.go
+++ b/api-service/service/oracle_database_licenses.go
@@ -23,3 +23,7 @@ func (as *APIService) UpdateLicenseIgnoredField(hostname string, dbname string, 
 
 	return nil
 }
+
+func (as *APIService) CanMigrateLicense(hostname string, dbname string) (bool, error) {
+	return as.Database.CanMigrateLicense(hostname, dbname)
+}

--- a/api-service/service/oracle_database_licenses_test.go
+++ b/api-service/service/oracle_database_licenses_test.go
@@ -116,3 +116,24 @@ func TestUpdateLicenseIgnoredField_Fail(t *testing.T) {
 	err := as.UpdateLicenseIgnoredField(hostname, dbname, licenseTypeID, ignored, "")
 	assert.EqualError(t, err, utils.ErrLicenseNotFound.Error())
 }
+
+func TestCanMigrateLicense(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	db := NewMockMongoDatabaseInterface(mockCtrl)
+	as := APIService{
+		Config: config.Configuration{
+			ResourceFilePath: "../../resources",
+		},
+		Database: db,
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		db.EXPECT().CanMigrateLicense("pippo", "pluto").Return(true, nil)
+
+		res, err := as.CanMigrateLicense("pippo", "pluto")
+
+		assert.Nil(t, err)
+		assert.True(t, res)
+	})
+}

--- a/api-service/service/service.go
+++ b/api-service/service/service.go
@@ -214,6 +214,8 @@ type APIServiceInterface interface {
 	// UpdateLicenseIgnoredField update license ignored field (true/false)
 	UpdateLicenseIgnoredField(hostname string, dbname string, licensetypeid string, ignored bool, ignoredComment string) error
 
+	CanMigrateLicense(hostname string, dbname string) (bool, error)
+
 	// UpdateSqlServerLicenseIgnoredField update license ignored field (true/false)
 	UpdateSqlServerLicenseIgnoredField(hostname string, instancename string, ignored bool, ignoredComment string) error
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -5251,6 +5251,33 @@ paths:
       parameters: []
       tags:
         - api-service
+  "/hosts/{hostname}/technologies/oracle/databases/{dbname}/can-migrate":
+    parameters:
+      - schema:
+          type: string
+        name: hostname
+        in: path
+        required: true
+      - schema:
+          type: string
+        name: dbname
+        in: path
+        required: true
+    get:
+      operationId: CanMigrateLicense
+      tags:
+        - api-service
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: 
+                type: object
+                properties:
+                  Canbemigrate:
+                    type: boolean
+            
   /contracts/microsoft/database:
     get:
       summary: Search Microsoft database contracts


### PR DESCRIPTION
Added new API `/hosts/{hostname}/technologies/oracle/databases/{dbname}/can-migrate` to return if an Oracle database can be migrated.
To know the status the rule is if a database has just an enterprise license this can be migrated to a standard license.
Resolve #1600 