### PR TITLE
Added target on host & db consumption

### DIFF
--- a/model/cpu_disk_consumption.go
+++ b/model/cpu_disk_consumption.go
@@ -21,6 +21,7 @@ import "time"
 type CpuDiskConsumption struct {
 	TimeStart  *time.Time `json:"timeStart" bson:"timeStart"`
 	TimeEnd    *time.Time `json:"timeEnd" bson:"timeEnd"`
+	Target     string     `json:"target,omitempty" bson:"target,omitempty"`
 	CpuDbAvg   *float64   `json:"cpuDbAvg,omitempty" bson:"cpuDbAvg,omitempty"`
 	CpuDbMax   *float64   `json:"cpuDbMax,omitempty" bson:"cpuDbMax,omitempty"`
 	CpuHostAvg *float64   `json:"cpuHostAvg,omitempty" bson:"cpuHostAvg,omitempty"`

--- a/model/cpu_disk_consumption_pdb.go
+++ b/model/cpu_disk_consumption_pdb.go
@@ -21,6 +21,7 @@ import "time"
 type CpuDiskConsumptionPdb struct {
 	TimeStart *time.Time `json:"timeStart" bson:"timeStart"`
 	TimeEnd   *time.Time `json:"timeEnd" bson:"timeEnd"`
+	Target    string     `json:"target,omitempty" bson:"target,omitempty"`
 	CpuDbAvg  *float64   `json:"cpuDbAvg,omitempty" bson:"cpuDbAvg,omitempty"`
 	CpuDbMax  *float64   `json:"cpuDbMax,omitempty" bson:"cpuDbMax,omitempty"`
 	IopsAvg   *float64   `json:"iopsAvg,omitempty" bson:"iopsAvg,omitempty"`

--- a/model/hostdata_cpu_consumption.go
+++ b/model/hostdata_cpu_consumption.go
@@ -21,5 +21,6 @@ import "time"
 type CpuConsumption struct {
 	TimeStart *time.Time `json:"timeStart" bson:"timeStart"`
 	TimeEnd   *time.Time `json:"timeEnd" bson:"timeEnd"`
+	Target    string     `json:"target,omitempty" bson:"target,omitempty"`
 	CpuAvg    *float64   `json:"cpuAvg,omitempty" bson:"cpuAvg,omitempty"`
 }

--- a/model/hostdata_disk_consumption.go
+++ b/model/hostdata_disk_consumption.go
@@ -21,6 +21,7 @@ import "time"
 type DiskConsumption struct {
 	TimeStart      *time.Time `json:"timeStart" bson:"timeStart"`
 	TimeEnd        *time.Time `json:"timeEnd" bson:"timeEnd"`
+	Target         string     `json:"target,omitempty" bson:"target,omitempty"`
 	IopsHostDayAvg *float64   `json:"iopsHostDayAvg,omitempty" bson:"iopsHostDayAvg,omitempty"`
 	IombHostDayAvg *float64   `json:"iombHostDayAvg,omitempty" bson:"iombHostDayAvg,omitempty"`
 }

--- a/schema/hostdata.json
+++ b/schema/hostdata.json
@@ -404,6 +404,9 @@
                                     }
                                 ]
                             },
+                            "target":{
+                                "type": "string"
+                            },
                             "cpuAvg": {
                                 "anyOf": [
                                     {"type": "null"},
@@ -440,6 +443,9 @@
                                         "format": "date-time"
                                     }
                                 ]
+                            },
+                            "target":{
+                                "type": "string"
                             },
                             "cpuDbAvg": {
                                 "anyOf": [

--- a/schema/oracle.json
+++ b/schema/oracle.json
@@ -767,6 +767,9 @@
                                                                             }
                                                                         ]
                                                                     },
+                                                                    "target":{
+                                                                        "type": "string"
+                                                                    },
                                                                     "cpuDbAvg": {
                                                                         "anyOf": [
                                                                             {"type": "null"},
@@ -889,6 +892,9 @@
                                                                     "format": "date-time"
                                                                 }
                                                             ]
+                                                        },
+                                                        "target":{
+                                                            "type": "string"
                                                         },
                                                         "cpuDbAvg": {
                                                             "anyOf": [


### PR DESCRIPTION
Added target to sort correctly data on ercole-web.
Target is a string and the value is the order in which the data are drawn on the consumption graph (like: `m, w1, d3...`)