### PR TITLE
Rounded oracle licenses

### DIFF
--- a/api-service/service/oracle_database_license_types.go
+++ b/api-service/service/oracle_database_license_types.go
@@ -93,6 +93,10 @@ func (as *APIService) GetOracleDatabaseLicensesCompliance() ([]dto.LicenseCompli
 		}
 
 		license.Consumed += usage.OriginalCount
+
+		if as.Config.APIService.RoundLicenses {
+			license.Consumed = math.Round(license.Consumed)
+		}
 	}
 
 	availableLicenses := make(map[string]float64)
@@ -114,8 +118,13 @@ func (as *APIService) GetOracleDatabaseLicensesCompliance() ([]dto.LicenseCompli
 			availableLicenses[contract.LicenseTypeID] += contract.AvailableLicensesPerCore
 		}
 
-		license.Covered += contract.CoveredLicenses
-		license.Purchased += (contract.LicensesPerCore + contract.LicensesPerUser)
+		if as.Config.APIService.RoundLicenses {
+			license.Covered += math.Round(contract.CoveredLicenses)
+			license.Purchased += math.Round((contract.LicensesPerCore + contract.LicensesPerUser))
+		} else {
+			license.Covered += contract.CoveredLicenses
+			license.Purchased += (contract.LicensesPerCore + contract.LicensesPerUser)
+		}
 	}
 
 	result := make([]dto.LicenseCompliance, 0, len(licenses))
@@ -131,7 +140,7 @@ func (as *APIService) GetOracleDatabaseLicensesCompliance() ([]dto.LicenseCompli
 			license.Compliance = license.Covered / license.Consumed
 		}
 
-		license.Available = availableLicenses[license.LicenseTypeID]
+		license.Available = math.Floor(availableLicenses[license.LicenseTypeID])
 
 		result = append(result, *license)
 	}

--- a/config.toml
+++ b/config.toml
@@ -71,6 +71,7 @@ Port = 11113
 LogHTTPRequest = true
 ReadOnly = false
 DebugOracleDatabaseAgreementsAssignmentAlgorithm = false
+RoundLicenses = false
 DefaultDatabaseTags = [
   "coolest",
   "very important",

--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,8 @@ type APIService struct {
 	DefaultDatabaseTags []string
 
 	OracleDatabasePoliciesAudit []string
+
+	RoundLicenses bool
 }
 
 // RepoService contains configuration about the repo service


### PR DESCRIPTION
Resolve #1823

Added boolean parameter in config, if true the license consumed, covered and purchased are rounded to the near integer.
The licenses available are always rounded down.